### PR TITLE
Explicit reference to core

### DIFF
--- a/eagle_exporter/collector.py
+++ b/eagle_exporter/collector.py
@@ -1,4 +1,4 @@
-import prometheus_client
+import prometheus_client.core
 
 
 class Eagle200Collector(object):


### PR DESCRIPTION
Fixes a bug: `AttributeError: module 'prometheus_client' has no attribute 'core'` With prometheus-client=0.16.0